### PR TITLE
reobfuscate_srg should be used

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -151,11 +151,11 @@
 
 		<!-- Reobfuscate -->
 		<exec dir="${mcp.dir}" executable="cmd" osfamily="windows">
-			<arg line="/c reobfuscate.bat"/>
+			<arg line="/c reobfuscate_srg.bat"/>
 		</exec>
 
 		<exec dir="${mcp.dir}" executable="sh" osfamily="unix">
-			<arg value="reobfuscate.sh"/>
+			<arg value="reobfuscate_srg.sh"/>
 		</exec>
 
 		<!-- Copy classes -->


### PR DESCRIPTION
reobfuscate_srg.\* should be used in favour of runtime deobfuscation and if one's lucky - "no recompile"-uses between minecraft versions
