### PR TITLE
1.7.10 renderdata for Railcraft

### DIFF
--- a/src/main/resources/renderdata/Railcraft-models.txt
+++ b/src/main/resources/renderdata/Railcraft-models.txt
@@ -1,10 +1,6 @@
 # Railcraft 8.3.2.0
-version:1.6
+version:1.7
 modname:Railcraft[7.3.0-]
-
-var:block.machine.gamma=0,block.detector=0,block.signal=0,block.machine.beta=0,block.machine.alpha=0,block.brick.bloodstained=0,block.stonelamp=0,block.fluid.steam=0,block.fluid.creosote=0,block.brick.quarried=0
-var:block.elevator=0,block.brick.abyssal=0,block.anvil=0,block.ore=0,block.brick.infernal=0,block.wall.alpha=0,block.track=0,block.firestone.recharge=0,block.brick.sandy=0,block.glass=0
-var:block.wall.beta=0,block.brick.bleachedbone=0,block.cube=0,block.worldlogic=0,block.stair=0,block.brick.frostbound=0,block.slab=0,block.post.metal=0,block.post=0,block.brick.nether=0
 
 cfgfile:config/railcraft/railcraft.cfg
 
@@ -26,45 +22,45 @@ patch:id=HorizY100ZTop,Ox=0.0,Oy=1.0,Oz=0.0,Ux=1.0,Uy=1.0,Uz=0.0,Vx=0.0,Vy=1.0,V
 
 patch:id=VertX0,Ox=0.0,Oy=0.0,Oz=1.0,Ux=0.0,Uy=0.0,Uz=0.0,Vx=0.0,Vy=1.0,Vz=1.0,visibility=top
 
-# block.detector:* (tile.railcraft.detector), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.detector.BlockDetector
-customblock:id=block.detector,data=*,class=org.dynmap.hdmap.renderer.RotatedBoxRenderer,textureIndex=direction,index0=0,map0=S312045,index1=1,map1=S032145,index2=2,map2=S012435,index3=3,map3=S012543,index4=4,map4=S013245,index5=5,map5=S012345
+# %tile.railcraft.detector:* (tile.railcraft.detector), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.detector.BlockDetector
+customblock:id=%tile.railcraft.detector,data=*,class=org.dynmap.hdmap.renderer.RotatedBoxRenderer,textureIndex=direction,index0=0,map0=S312045,index1=1,map1=S032145,index2=2,map2=S012435,index3=3,map3=S012543,index4=4,map4=S013245,index5=5,map5=S012345
 
-# block.machine.gamma:* (tile.railcraft.machine.gamma), render=0(STANDARD), opaque=false,cls=mods.railcraft.common.blocks.machine.BlockMachine
-customblock:id=block.machine.gamma,data=*,class=org.dynmap.hdmap.renderer.RotatedBoxRenderer,textureIndex=direction,index0=0,map0=S312045,index1=1,map1=S032145,index2=2,map2=S012435,index3=3,map3=S012543,index4=4,map4=S013245,index5=5,map5=S012345
+# %tile.railcraft.machine.gamma:* (tile.railcraft.machine.gamma), render=0(STANDARD), opaque=false,cls=mods.railcraft.common.blocks.machine.BlockMachine
+customblock:id=%tile.railcraft.machine.gamma,data=*,class=org.dynmap.hdmap.renderer.RotatedBoxRenderer,textureIndex=direction,index0=0,map0=S312045,index1=1,map1=S032145,index2=2,map2=S012435,index3=3,map3=S012543,index4=4,map4=S013245,index5=5,map5=S012345
 
-# block.machine.beta:* (tile.railcraft.machine.beta), render=67(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.machine.BlockMachine
+# %tile.railcraft.machine.beta:* (tile.railcraft.machine.beta), render=67(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.machine.BlockMachine
 
-# block.track:* (tile.railcraft.track), render=56(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.tracks.BlockTrack
-customblock:id=block.track,data=0,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop,maxTrackId=41
-customblock:id=block.track,data=1,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop@90,maxTrackId=41
-customblock:id=block.track,data=2,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop,maxTrackId=41
-customblock:id=block.track,data=3,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@180,maxTrackId=41
-customblock:id=block.track,data=4,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@270,maxTrackId=41
-customblock:id=block.track,data=5,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@90,maxTrackId=41
-customblock:id=block.track,data=6,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop@90,maxTrackId=41
-customblock:id=block.track,data=7,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop@180,maxTrackId=41
-customblock:id=block.track,data=8,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop@270,maxTrackId=41
-customblock:id=block.track,data=9,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop,maxTrackId=41
-customblock:id=block.track,data=10,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop,maxTrackId=41
-customblock:id=block.track,data=11,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@180,maxTrackId=41
-customblock:id=block.track,data=12,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@270,maxTrackId=41
-customblock:id=block.track,data=13,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@90,maxTrackId=41
+# %tile.railcraft.track:* (tile.railcraft.track), render=56(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.tracks.BlockTrack
+customblock:id=%tile.railcraft.track,data=0,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=1,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop@90,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=2,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=3,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@180,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=4,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@270,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=5,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@90,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=6,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop@90,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=7,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop@180,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=8,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop@270,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=9,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=HorizY001ZTop,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=10,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=11,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@180,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=12,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@270,maxTrackId=41
+customblock:id=%tile.railcraft.track,data=13,class=org.dynmap.hdmap.renderer.RailCraftTrackRenderer,patch=SlopeXUpZTop@90,maxTrackId=41
 
-# block.elevator:* (tile.railcraft.track.elevator), render=57(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.tracks.BlockTrackElevator
-patchblock:id=block.elevator,data=2,data=10,patch0=VertX0@270
-patchblock:id=block.elevator,data=3,data=11,patch0=VertX0@90
-patchblock:id=block.elevator,data=4,data=12,patch0=VertX0@180
-patchblock:id=block.elevator,data=5,data=13,patch0=VertX0
+# %tile.railcraft.track.elevator:* (tile.railcraft.track.elevator), render=57(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.tracks.BlockTrackElevator
+patchblock:id=%tile.railcraft.track.elevator,data=2,data=10,patch0=VertX0@270
+patchblock:id=%tile.railcraft.track.elevator,data=3,data=11,patch0=VertX0@90
+patchblock:id=%tile.railcraft.track.elevator,data=4,data=12,patch0=VertX0@180
+patchblock:id=%tile.railcraft.track.elevator,data=5,data=13,patch0=VertX0
 
-# block.signal:* (tile.railcraft.signal), render=58(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.signals.BlockSignal
-block:id=block.signal,data=0,scale=4
+# %tile.railcraft.signal:* (tile.railcraft.signal), render=58(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.signals.BlockSignal
+block:id=%tile.railcraft.signal,data=0,scale=4
 layer:0,1,2,3
 ----
 -**-
 -**-
 ----
-# (block.signal:1) dual head block signal
-block:id=block.signal,data=1,scale=16
+# (%tile.railcraft.signal:1) dual head block signal
+block:id=%tile.railcraft.signal,data=1,scale=16
 layer:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 ----------------
 ----------------
@@ -82,9 +78,9 @@ layer:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 ----------------
 ----------------
 ----------------
-# (block.signal:2) switch motor
-# (block.signal:4) switch lever
-block:id=block.signal,data=2,data=4,scale=16
+# (%tile.railcraft.signal:2) switch motor
+# (%tile.railcraft.signal:4) switch lever
+block:id=%tile.railcraft.signal,data=2,data=4,scale=16
 layer:0,1,2
 ------****------
 ------****------
@@ -155,9 +151,9 @@ layer:8,9,10
 ----------------
 ----------------
 ----------------
-# (block.signal:3) signal light
-# (block.signal:10) distant signal light
-block:id=block.signal,data=3,data=10,scale=16
+# (%tile.railcraft.signal:3) signal light
+# (%tile.railcraft.signal:10) distant signal light
+block:id=%tile.railcraft.signal,data=3,data=10,scale=16
 layer:0,1,2,3,4
 ----------------
 ----------------
@@ -192,9 +188,9 @@ layer:5,6,7,8,9,10,11,12,13,14
 ----------------
 ----------------
 ----------------
-# (block.signal:5) wood post
-# (block.signal:6) stone post
-block:id=block.signal,data=5,data=6,scale=16
+# (%tile.railcraft.signal:5) wood post
+# (%tile.railcraft.signal:6) stone post
+block:id=%tile.railcraft.signal,data=5,data=6,scale=16
 layer:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 ----------------
 ----------------
@@ -212,9 +208,9 @@ layer:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 ----------------
 ----------------
 ----------------
-# (block.signal:8) signal box receiver
-# (block.signal:9) signal box controller
-block:id=block.signal,data=8,data=9,scale=16
+# (%tile.railcraft.signal:8) signal box receiver
+# (%tile.railcraft.signal:9) signal box controller
+block:id=%tile.railcraft.signal,data=8,data=9,scale=16
 layer:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 ----------------
 ----------------
@@ -233,30 +229,30 @@ layer:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 ----------------
 ----------------
 
-# block.ore:* (tile.railcraft.ore), render=68(CUSTOM), opaque=true,cls=mods.railcraft.common.blocks.ore.BlockOre
+# %tile.railcraft.ore:* (tile.railcraft.ore), render=68(CUSTOM), opaque=true,cls=mods.railcraft.common.blocks.ore.BlockOre
 
-# block.post:* (tile.railcraft.post), render=59(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.post.BlockPost
-# block.post.metal:* (tile.railcraft.post.metal), render=60(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.post.BlockPostMetal
-customblock:id=block.post,id=block.post.metal,data=*,class=org.dynmap.hdmap.renderer.FenceWallBlockRenderer,type=fence,link0=107
+# %tile.railcraft.post:* (tile.railcraft.post), render=59(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.post.BlockPost
+# %tile.railcraft.post.metal:* (tile.railcraft.post.metal), render=60(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.post.BlockPostMetal
+customblock:id=%tile.railcraft.post,id=%tile.railcraft.post.metal,data=*,class=org.dynmap.hdmap.renderer.FenceWallBlockRenderer,type=fence,link0=107
 
-# block.wall.alpha:* (tile.railcraft.wall.alpha), render=61(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.wall.BlockRailcraftWall
-# block.wall.beta:* (tile.railcraft.wall.beta), render=62(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.wall.BlockRailcraftWall
-customblock:id=block.wall.alpha,id=block.wall.beta,data=*,class=org.dynmap.hdmap.renderer.FenceWallBlockRenderer,type=wall,link0=107,link1=block.wall.alpha,link2=block.wall.beta
+# %tile.railcraft.wall.alpha:* (tile.railcraft.wall.alpha), render=61(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.wall.BlockRailcraftWall
+# %tile.railcraft.wall.beta:* (tile.railcraft.wall.beta), render=62(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.wall.BlockRailcraftWall
+customblock:id=%tile.railcraft.wall.alpha,id=%tile.railcraft.wall.beta,data=*,class=org.dynmap.hdmap.renderer.FenceWallBlockRenderer,type=wall,link0=107,link1=%tile.railcraft.wall.alpha,link2=%tile.railcraft.wall.beta
 
-# block.stair:* (tile.railcraft.stair), render=63(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.stairs.BlockRailcraftStairs
-customblock:id=block.stair,data=*,class=org.dynmap.hdmap.renderer.StairBlockRenderer,textureindex=stair,texturecnt=34,textmap0=SANDY_BRICK,textmap1=INFERNAL_BRICK,textmap2=CONCRETE,textmap3=SNOW,,textmap4=ICE,textmap5=IRON,textmap6=GOLD,textmap7=DIAMOND,textmap8=FROSTBOUND_BRICK,textmap9=QUARRIED_BRICK,textmap10=BLEACHEDBONE_BRICK,textmap11=BLOODSTAINED_BRICK,textmap12=ABYSSAL_BRICK,textmap13=SANDY_FITTED,textmap14=INFERNAL_FITTED,textmap15=FROSTBOUND_FITTED,textmap16=QUARRIED_FITTED,textmap17=BLEACHEDBONE_FITTED,textmap18=BLOODSTAINED_FITTED,textmap19=ABYSSAL_FITTED,textmap20=SANDY_BLOCK,textmap21=INFERNAL_BLOCK,textmap22=FROSTBOUND_BLOCK,textmap23=QUARRIED_BLOCK,textmap24=BLEACHEDBONE_BLOCK,textmap25=BLOODSTAINED_BLOCK,textmap26=ABYSSAL_BLOCK,textmap27=SANDY_COBBLE,textmap28=INFERNAL_COBBLE,textmap29=FROSTBOUND_COBBLE,textmap30=QUARRIED_COBBLE,textmap31=BLEACHEDBONE_COBBLE,textmap32=BLOODSTAINED_COBBLE,textmap33=ABYSSAL_COBBLE,textmap34=NETHER_COBBLE,textmap35=CREOSOTE
+# %tile.railcraft.stair:* (tile.railcraft.stair), render=63(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.stairs.BlockRailcraftStairs
+customblock:id=%tile.railcraft.stair,data=*,class=org.dynmap.hdmap.renderer.StairBlockRenderer,textureindex=stair,texturecnt=34,textmap0=SANDY_BRICK,textmap1=INFERNAL_BRICK,textmap2=CONCRETE,textmap3=SNOW,,textmap4=ICE,textmap5=IRON,textmap6=GOLD,textmap7=DIAMOND,textmap8=FROSTBOUND_BRICK,textmap9=QUARRIED_BRICK,textmap10=BLEACHEDBONE_BRICK,textmap11=BLOODSTAINED_BRICK,textmap12=ABYSSAL_BRICK,textmap13=SANDY_FITTED,textmap14=INFERNAL_FITTED,textmap15=FROSTBOUND_FITTED,textmap16=QUARRIED_FITTED,textmap17=BLEACHEDBONE_FITTED,textmap18=BLOODSTAINED_FITTED,textmap19=ABYSSAL_FITTED,textmap20=SANDY_BLOCK,textmap21=INFERNAL_BLOCK,textmap22=FROSTBOUND_BLOCK,textmap23=QUARRIED_BLOCK,textmap24=BLEACHEDBONE_BLOCK,textmap25=BLOODSTAINED_BLOCK,textmap26=ABYSSAL_BLOCK,textmap27=SANDY_COBBLE,textmap28=INFERNAL_COBBLE,textmap29=FROSTBOUND_COBBLE,textmap30=QUARRIED_COBBLE,textmap31=BLEACHEDBONE_COBBLE,textmap32=BLOODSTAINED_COBBLE,textmap33=ABYSSAL_COBBLE,textmap34=NETHER_COBBLE,textmap35=CREOSOTE
 
-# block.slab:* (tile.railcraft.slab), render=64(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.slab.BlockRailcraftSlab
-customblock:id=block.slab,data=*,class=org.dynmap.hdmap.renderer.RailCraftSlabBlockRenderer,texturecnt=34,textmap0=SANDY_BRICK,textmap1=INFERNAL_BRICK,textmap2=CONCRETE,textmap3=SNOW,,textmap4=ICE,textmap5=IRON,textmap6=GOLD,textmap7=DIAMOND,textmap8=FROSTBOUND_BRICK,textmap9=QUARRIED_BRICK,textmap10=BLEACHEDBONE_BRICK,textmap11=BLOODSTAINED_BRICK,textmap12=ABYSSAL_BRICK,textmap13=SANDY_FITTED,textmap14=INFERNAL_FITTED,textmap15=FROSTBOUND_FITTED,textmap16=QUARRIED_FITTED,textmap17=BLEACHEDBONE_FITTED,textmap18=BLOODSTAINED_FITTED,textmap19=ABYSSAL_FITTED,textmap20=SANDY_BLOCK,textmap21=INFERNAL_BLOCK,textmap22=FROSTBOUND_BLOCK,textmap23=QUARRIED_BLOCK,textmap24=BLEACHEDBONE_BLOCK,textmap25=BLOODSTAINED_BLOCK,textmap26=ABYSSAL_BLOCK,textmap27=SANDY_COBBLE,textmap28=INFERNAL_COBBLE,textmap29=FROSTBOUND_COBBLE,textmap30=QUARRIED_COBBLE,textmap31=BLEACHEDBONE_COBBLE,textmap32=BLOODSTAINED_COBBLE,textmap33=ABYSSAL_COBBLE,textmap34=NETHER_COBBLE,textmap35=CREOSOTE
+# %tile.railcraft.slab:* (tile.railcraft.slab), render=64(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.slab.BlockRailcraftSlab
+customblock:id=%tile.railcraft.slab,data=*,class=org.dynmap.hdmap.renderer.RailCraftSlabBlockRenderer,texturecnt=34,textmap0=SANDY_BRICK,textmap1=INFERNAL_BRICK,textmap2=CONCRETE,textmap3=SNOW,,textmap4=ICE,textmap5=IRON,textmap6=GOLD,textmap7=DIAMOND,textmap8=FROSTBOUND_BRICK,textmap9=QUARRIED_BRICK,textmap10=BLEACHEDBONE_BRICK,textmap11=BLOODSTAINED_BRICK,textmap12=ABYSSAL_BRICK,textmap13=SANDY_FITTED,textmap14=INFERNAL_FITTED,textmap15=FROSTBOUND_FITTED,textmap16=QUARRIED_FITTED,textmap17=BLEACHEDBONE_FITTED,textmap18=BLOODSTAINED_FITTED,textmap19=ABYSSAL_FITTED,textmap20=SANDY_BLOCK,textmap21=INFERNAL_BLOCK,textmap22=FROSTBOUND_BLOCK,textmap23=QUARRIED_BLOCK,textmap24=BLEACHEDBONE_BLOCK,textmap25=BLOODSTAINED_BLOCK,textmap26=ABYSSAL_BLOCK,textmap27=SANDY_COBBLE,textmap28=INFERNAL_COBBLE,textmap29=FROSTBOUND_COBBLE,textmap30=QUARRIED_COBBLE,textmap31=BLEACHEDBONE_COBBLE,textmap32=BLOODSTAINED_COBBLE,textmap33=ABYSSAL_COBBLE,textmap34=NETHER_COBBLE,textmap35=CREOSOTE
 
-# block.glass:* (tile.railcraft.glass), render=65(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.glass.BlockStrengthGlass
-customblock:id=block.glass,data=*,class=org.dynmap.hdmap.renderer.CTMVertTextureRenderer
+# %tile.railcraft.glass:* (tile.railcraft.glass), render=65(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.glass.BlockStrengthGlass
+customblock:id=%tile.railcraft.glass,data=*,class=org.dynmap.hdmap.renderer.CTMVertTextureRenderer
 
-# block.firestone.recharge:* (tile.block.firestone.recharge), render=-1(CUSTOM), opaque=false,cls=mods.railcraft.common.items.firestone.BlockFirestoneRecharge
-# block.anvil:* (tile.railcraft.block.anvil), render=35(ANVIL), opaque=false,cls=mods.railcraft.common.blocks.anvil.BlockRCAnvil
+# %tile.railcraft.firestone.recharge:* (tile.block.firestone.recharge), render=-1(CUSTOM), opaque=false,cls=mods.railcraft.common.items.firestone.BlockFirestoneRecharge
+# %tile.railcraft.anvil:* (tile.railcraft.block.anvil), render=35(ANVIL), opaque=false,cls=mods.railcraft.common.blocks.anvil.BlockRCAnvil
 
-# block.stonelamp:* (tile.railcraft.stonelamp), render=66(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.lamp.BlockStoneLamp
-block:id=block.stonelamp,data=*,scale=16
+# %tile.railcraft.stonelamp:* (tile.railcraft.stonelamp), render=66(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.lamp.BlockStoneLamp
+block:id=%tile.railcraft.stonelamp,data=*,scale=16
 layer:4,5
 ----------------
 ----------------
@@ -343,12 +339,12 @@ layer:14
 ----------------
 ----------------
 
-# block.fluid.creosote:* (tile.railcraft.block.fluid.creosote), render=40(CUSTOM), opaque=false,cls=mods.railcraft.common.fluids.BlockRailcraftFluid
-# block.fluid.steam:* (tile.railcraft.block.fluid.steam), render=40(CUSTOM), opaque=false,cls=mods.railcraft.common.fluids.BlockRailcraftFluidFinite
-boxblock:id=block.fluid.creosote,id=block.fluid.steam,data=1,ymax=0.875
-boxblock:id=block.fluid.creosote,id=block.fluid.steam,data=2,ymax=0.75
-boxblock:id=block.fluid.creosote,id=block.fluid.steam,data=3,ymax=0.625
-boxblock:id=block.fluid.creosote,id=block.fluid.steam,data=4,ymax=0.5
-boxblock:id=block.fluid.creosote,id=block.fluid.steam,data=5,ymax=0.375
-boxblock:id=block.fluid.creosote,id=block.fluid.steam,data=6,ymax=0.25
-boxblock:id=block.fluid.creosote,id=block.fluid.steam,data=7,ymax=0.125
+# %tile.railcraft.fluid.creosote:* (tile.railcraft.block.fluid.creosote), render=40(CUSTOM), opaque=false,cls=mods.railcraft.common.fluids.BlockRailcraftFluid
+# %tile.railcraft.fluid.steam:* (tile.railcraft.block.fluid.steam), render=40(CUSTOM), opaque=false,cls=mods.railcraft.common.fluids.BlockRailcraftFluidFinite
+boxblock:id=%tile.railcraft.fluid.creosote,id=%tile.railcraft.fluid.steam,data=1,ymax=0.875
+boxblock:id=%tile.railcraft.fluid.creosote,id=%tile.railcraft.fluid.steam,data=2,ymax=0.75
+boxblock:id=%tile.railcraft.fluid.creosote,id=%tile.railcraft.fluid.steam,data=3,ymax=0.625
+boxblock:id=%tile.railcraft.fluid.creosote,id=%tile.railcraft.fluid.steam,data=4,ymax=0.5
+boxblock:id=%tile.railcraft.fluid.creosote,id=%tile.railcraft.fluid.steam,data=5,ymax=0.375
+boxblock:id=%tile.railcraft.fluid.creosote,id=%tile.railcraft.fluid.steam,data=6,ymax=0.25
+boxblock:id=%tile.railcraft.fluid.creosote,id=%tile.railcraft.fluid.steam,data=7,ymax=0.125

--- a/src/main/resources/renderdata/Railcraft-texture.txt
+++ b/src/main/resources/renderdata/Railcraft-texture.txt
@@ -1,10 +1,6 @@
 # Railcraft 8.3.2.0
-version:1.6
+version:1.7
 modname:Railcraft[7.3.0-]
-
-var:block.machine.gamma=0,block.detector=0,block.signal=0,block.machine.beta=0,block.machine.alpha=0,block.brick.bloodstained=0,block.stonelamp=0,block.fluid.steam=0,block.fluid.creosote=0,block.brick.quarried=0
-var:block.elevator=0,block.brick.abyssal=0,block.anvil=0,block.ore=0,block.brick.infernal=0,block.wall.alpha=0,block.track=0,block.firestone.recharge=0,block.brick.sandy=0,block.glass=0
-var:block.wall.beta=0,block.brick.bleachedbone=0,block.cube=0,block.worldlogic=0,block.stair=0,block.brick.frostbound=0,block.slab=0,block.post.metal=0,block.post=0,block.brick.nether=0
 
 cfgfile:config/railcraft/railcraft.cfg
 
@@ -175,266 +171,266 @@ texture:id=track39,filename=assets/railcraft/textures/blocks/tracks/track.locomo
 texture:id=track40,filename=assets/railcraft/textures/blocks/tracks/track.limiter.png,xcount=5
 texture:id=track41,filename=assets/railcraft/textures/blocks/tracks/track.routing.png,xcount=2
 
-# block.detector:* (tile.railcraft.detector), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.detector.BlockDetector
-block:id=block.detector,data=0,stdrot=true,face0-2=0:railcraft/detector.item,face3=2:railcraft/detector.item,face4-5=0:railcraft/detector.item
-block:id=block.detector,data=1,stdrot=true,face0-2=0:railcraft/detector.any,face3=2:railcraft/detector.any,face4-5=0:railcraft/detector.any
-block:id=block.detector,data=2,stdrot=true,face0-2=0:railcraft/detector.empty,face3=2:railcraft/detector.empty,face4-5=0:railcraft/detector.empty
-block:id=block.detector,data=3,stdrot=true,face0-2=0:railcraft/detector.mob,face3=2:railcraft/detector.mob,face4-5=0:railcraft/detector.mob
-block:id=block.detector,data=4,stdrot=true,face0-2=0:railcraft/detector.powered,face3=2:railcraft/detector.powered,face4-5=0:railcraft/detector.powered
-block:id=block.detector,data=5,stdrot=true,face0-2=0:railcraft/detector.player,face3=2:railcraft/detector.player,face4-5=0:railcraft/detector.player
-block:id=block.detector,data=6,stdrot=true,face0-2=0:railcraft/detector.explosive,face3=2:railcraft/detector.explosive,face4-5=0:railcraft/detector.explosive
-block:id=block.detector,data=7,stdrot=true,face0-2=0:railcraft/detector.animal,face3=2:railcraft/detector.animal,face4-5=0:railcraft/detector.animal
-block:id=block.detector,data=8,stdrot=true,face0-2=0:railcraft/detector.tank,face3=2:railcraft/detector.tank,face4-5=0:railcraft/detector.tank
-block:id=block.detector,data=9,stdrot=true,face0-2=0:railcraft/detector.advanced,face3=2:railcraft/detector.advanced,face4-5=0:railcraft/detector.advanced
-block:id=block.detector,data=10,stdrot=true,face0-2=0:railcraft/detector.energy,face3=2:railcraft/detector.energy,face4-5=0:railcraft/detector.energy
-block:id=block.detector,data=11,stdrot=true,face0-2=0:railcraft/detector.age,face3=2:railcraft/detector.age,face4-5=0:railcraft/detector.age
-block:id=block.detector,data=12,stdrot=true,face0-2=0:railcraft/detector.train,face3=2:railcraft/detector.train,face4-5=0:railcraft/detector.train
-block:id=block.detector,data=13,stdrot=true,face0-2=0:railcraft/detector.sheep,face3=2:railcraft/detector.sheep,face4-5=0:railcraft/detector.sheep
-block:id=block.detector,data=14,stdrot=true,face0-2=0:railcraft/detector.villager,face3=2:railcraft/detector.villager,face4-5=0:railcraft/detector.villager
-block:id=block.detector,data=15,stdrot=true,face0-2=0:railcraft/detector.locomotive,face3=2:railcraft/detector.locomotive,face4-5=0:railcraft/detector.locomotive
-# block.machine.alpha:* (tile.railcraft.machine.alpha), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.machine.BlockMachine
-block:id=block.machine.alpha,data=0,stdrot=true,face0-1=0:railcraft/anchor.world,face2-5=1:railcraft/anchor.world
-block:id=block.machine.alpha,data=1,stdrot=true,face0-3=2:railcraft/turbine,face4=6:railcraft/turbine,face5=2:railcraft/turbine
-block:id=block.machine.alpha,data=2,stdrot=true,face0-1=0:railcraft/anchor.personal,face2-5=1:railcraft/anchor.personal
-block:id=block.machine.alpha,data=3,stdrot=true,face0-1=2:railcraft/steam.oven,face2-3=3:railcraft/steam.oven,face4=6:railcraft/steam.oven,face5=3:railcraft/steam.oven
-block:id=block.machine.alpha,data=4,stdrot=true,face0-1=0:railcraft/anchor.admin,face2-5=1:railcraft/anchor.admin
-block:id=block.machine.alpha,data=5,stdrot=true,face0=0:railcraft/smoker,face1=1:railcraft/smoker,face2-5=2:railcraft/smoker
-block:id=block.machine.alpha,data=7,stdrot=true,face0-3=0:railcraft/coke.oven,face4=1:railcraft/coke.oven,face5=0:railcraft/coke.oven
-block:id=block.machine.alpha,data=8,stdrot=true,face0=0:railcraft/rolling.machine,face1=1:railcraft/rolling.machine,face2-5=2:railcraft/rolling.machine
-block:id=block.machine.alpha,data=9,stdrot=true,face0=0:railcraft/steam.trap,face1=2:railcraft/steam.trap,face2-5=1:railcraft/steam.trap
-block:id=block.machine.alpha,data=10,stdrot=true,face0=0:railcraft/steam.trap.auto,face1=2:railcraft/steam.trap.auto,face2-5=1:railcraft/steam.trap.auto
-block:id=block.machine.alpha,data=11,stdrot=true,face0-1=0:railcraft/feed.station,face2-5=1:railcraft/feed.station
-block:id=block.machine.alpha,data=12,stdrot=true,face0-3=0:railcraft/blast.furnace,face4=1:railcraft/blast.furnace,face5=0:railcraft/blast.furnace
-block:id=block.machine.alpha,data=13,stdrot=true,face0=0:railcraft/engraving.bench,face1=1:railcraft/engraving.bench,face2-5=3:railcraft/engraving.bench
-block:id=block.machine.alpha,data=14,stdrot=true,face0-1=0:railcraft/tank.water,face2-5=1:railcraft/tank.water
-block:id=block.machine.alpha,data=15,stdrot=true,face0=3:railcraft/rock.crusher,face1=11:railcraft/rock.crusher,face2-3=3:railcraft/rock.crusher,face4=7:railcraft/rock.crusher,face5=3:railcraft/rock.crusher
-# block.machine.beta:* (tile.railcraft.machine.beta), render=67(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.machine.BlockMachine
-block:id=block.machine.beta,data=0,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/tank.iron.wall,face2-5=1:railcraft/tank.iron.wall
-block:id=block.machine.beta,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/tank.iron.gauge
-block:id=block.machine.beta,data=2,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/tank.iron.valve,face2-5=1:railcraft/tank.iron.valve
-block:id=block.machine.beta,data=3,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/boiler.tank.pressure.low,face2-5=1:railcraft/boiler.tank.pressure.low
-block:id=block.machine.beta,data=4,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/boiler.tank.pressure.high,face2-5=1:railcraft/boiler.tank.pressure.high
-block:id=block.machine.beta,data=5,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/boiler.firebox.solid,face2-5=1:railcraft/boiler.firebox.solid
-block:id=block.machine.beta,data=6,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/boiler.firebox.liquid,face2-5=1:railcraft/boiler.firebox.liquid
-block:id=block.machine.beta,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/engine.steam.hobby
-block:id=block.machine.beta,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/engine.steam.low
-block:id=block.machine.beta,data=9,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/engine.steam.high
-block:id=block.machine.beta,data=10,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/anchor.sentinel,face2-5=1:railcraft/anchor.sentinel
-block:id=block.machine.beta,data=11,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/chest.void
-block:id=block.machine.beta,data=13,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/tank.steel.wall,face2-5=1:railcraft/tank.steel.wall
-block:id=block.machine.beta,data=14,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/tank.steel.gauge
-block:id=block.machine.beta,data=15,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/tank.steel.valve,face2-5=1:railcraft/tank.steel.valve
-# block.machine.gamma:* (tile.railcraft.machine.gamma), render=0(STANDARD), opaque=false,cls=mods.railcraft.common.blocks.machine.BlockMachine
-block:id=block.machine.gamma,data=0,stdrot=true,face0=2:railcraft/loader.item,face1=0:railcraft/loader.item,face2-5=1:railcraft/loader.item
-block:id=block.machine.gamma,data=1,stdrot=true,face0=0:railcraft/unloader.item,face1=2:railcraft/unloader.item,face2-5=1:railcraft/unloader.item
-block:id=block.machine.gamma,data=2,stdrot=true,face0-1=0:railcraft/loader.item.advanced,face2=1:railcraft/loader.item.advanced,face3=2:railcraft/loader.item.advanced,face4-5=1:railcraft/loader.item.advanced
-block:id=block.machine.gamma,data=3,stdrot=true,face0-1=0:railcraft/unloader.item.advanced,face2=1:railcraft/unloader.item.advanced,face3=2:railcraft/unloader.item.advanced,face4-5=1:railcraft/unloader.item.advanced
-block:id=block.machine.gamma,data=4,stdrot=true,face0=2:railcraft/loader.liquid,face1=0:railcraft/loader.liquid,face2-5=1:railcraft/loader.liquid
-block:id=block.machine.gamma,data=5,stdrot=true,face0=0:railcraft/unloader.liquid,face1=2:railcraft/unloader.liquid,face2-5=1:railcraft/unloader.liquid
-block:id=block.machine.gamma,data=6,stdrot=true,face0-1=0:railcraft/loader.energy,face2=1:railcraft/loader.energy,face3=2:railcraft/loader.energy,face4-5=1:railcraft/loader.energy
-block:id=block.machine.gamma,data=7,stdrot=true,face0-1=0:railcraft/unloader.energy,face2=1:railcraft/unloader.energy,face3=2:railcraft/unloader.energy,face4-5=1:railcraft/unloader.energy
-block:id=block.machine.gamma,data=8,stdrot=true,face0-1=0:railcraft/dispenser.cart,face2=1:railcraft/dispenser.cart,face3=2:railcraft/dispenser.cart,face4-5=1:railcraft/dispenser.cart
-block:id=block.machine.gamma,data=9,stdrot=true,face0-1=0:railcraft/dispenser.train,face2=1:railcraft/dispenser.train,face3=2:railcraft/dispenser.train,face4-5=1:railcraft/dispenser.train
-block:id=block.machine.gamma,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0=2:railcraft/loader.item,face1=0:railcraft/loader.item,face2-5=1:railcraft/loader.item
+# %tile.railcraft.detector:* (tile.railcraft.detector), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.detector.BlockDetector
+block:id=%tile.railcraft.detector,data=0,stdrot=true,face0-2=0:railcraft/detector.item,face3=2:railcraft/detector.item,face4-5=0:railcraft/detector.item
+block:id=%tile.railcraft.detector,data=1,stdrot=true,face0-2=0:railcraft/detector.any,face3=2:railcraft/detector.any,face4-5=0:railcraft/detector.any
+block:id=%tile.railcraft.detector,data=2,stdrot=true,face0-2=0:railcraft/detector.empty,face3=2:railcraft/detector.empty,face4-5=0:railcraft/detector.empty
+block:id=%tile.railcraft.detector,data=3,stdrot=true,face0-2=0:railcraft/detector.mob,face3=2:railcraft/detector.mob,face4-5=0:railcraft/detector.mob
+block:id=%tile.railcraft.detector,data=4,stdrot=true,face0-2=0:railcraft/detector.powered,face3=2:railcraft/detector.powered,face4-5=0:railcraft/detector.powered
+block:id=%tile.railcraft.detector,data=5,stdrot=true,face0-2=0:railcraft/detector.player,face3=2:railcraft/detector.player,face4-5=0:railcraft/detector.player
+block:id=%tile.railcraft.detector,data=6,stdrot=true,face0-2=0:railcraft/detector.explosive,face3=2:railcraft/detector.explosive,face4-5=0:railcraft/detector.explosive
+block:id=%tile.railcraft.detector,data=7,stdrot=true,face0-2=0:railcraft/detector.animal,face3=2:railcraft/detector.animal,face4-5=0:railcraft/detector.animal
+block:id=%tile.railcraft.detector,data=8,stdrot=true,face0-2=0:railcraft/detector.tank,face3=2:railcraft/detector.tank,face4-5=0:railcraft/detector.tank
+block:id=%tile.railcraft.detector,data=9,stdrot=true,face0-2=0:railcraft/detector.advanced,face3=2:railcraft/detector.advanced,face4-5=0:railcraft/detector.advanced
+block:id=%tile.railcraft.detector,data=10,stdrot=true,face0-2=0:railcraft/detector.energy,face3=2:railcraft/detector.energy,face4-5=0:railcraft/detector.energy
+block:id=%tile.railcraft.detector,data=11,stdrot=true,face0-2=0:railcraft/detector.age,face3=2:railcraft/detector.age,face4-5=0:railcraft/detector.age
+block:id=%tile.railcraft.detector,data=12,stdrot=true,face0-2=0:railcraft/detector.train,face3=2:railcraft/detector.train,face4-5=0:railcraft/detector.train
+block:id=%tile.railcraft.detector,data=13,stdrot=true,face0-2=0:railcraft/detector.sheep,face3=2:railcraft/detector.sheep,face4-5=0:railcraft/detector.sheep
+block:id=%tile.railcraft.detector,data=14,stdrot=true,face0-2=0:railcraft/detector.villager,face3=2:railcraft/detector.villager,face4-5=0:railcraft/detector.villager
+block:id=%tile.railcraft.detector,data=15,stdrot=true,face0-2=0:railcraft/detector.locomotive,face3=2:railcraft/detector.locomotive,face4-5=0:railcraft/detector.locomotive
+# %tile.railcraft.machine.alpha:* (tile.railcraft.machine.alpha), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.machine.BlockMachine
+block:id=%tile.railcraft.machine.alpha,data=0,stdrot=true,face0-1=0:railcraft/anchor.world,face2-5=1:railcraft/anchor.world
+block:id=%tile.railcraft.machine.alpha,data=1,stdrot=true,face0-3=2:railcraft/turbine,face4=6:railcraft/turbine,face5=2:railcraft/turbine
+block:id=%tile.railcraft.machine.alpha,data=2,stdrot=true,face0-1=0:railcraft/anchor.personal,face2-5=1:railcraft/anchor.personal
+block:id=%tile.railcraft.machine.alpha,data=3,stdrot=true,face0-1=2:railcraft/steam.oven,face2-3=3:railcraft/steam.oven,face4=6:railcraft/steam.oven,face5=3:railcraft/steam.oven
+block:id=%tile.railcraft.machine.alpha,data=4,stdrot=true,face0-1=0:railcraft/anchor.admin,face2-5=1:railcraft/anchor.admin
+block:id=%tile.railcraft.machine.alpha,data=5,stdrot=true,face0=0:railcraft/smoker,face1=1:railcraft/smoker,face2-5=2:railcraft/smoker
+block:id=%tile.railcraft.machine.alpha,data=7,stdrot=true,face0-3=0:railcraft/coke.oven,face4=1:railcraft/coke.oven,face5=0:railcraft/coke.oven
+block:id=%tile.railcraft.machine.alpha,data=8,stdrot=true,face0=0:railcraft/rolling.machine,face1=1:railcraft/rolling.machine,face2-5=2:railcraft/rolling.machine
+block:id=%tile.railcraft.machine.alpha,data=9,stdrot=true,face0=0:railcraft/steam.trap,face1=2:railcraft/steam.trap,face2-5=1:railcraft/steam.trap
+block:id=%tile.railcraft.machine.alpha,data=10,stdrot=true,face0=0:railcraft/steam.trap.auto,face1=2:railcraft/steam.trap.auto,face2-5=1:railcraft/steam.trap.auto
+block:id=%tile.railcraft.machine.alpha,data=11,stdrot=true,face0-1=0:railcraft/feed.station,face2-5=1:railcraft/feed.station
+block:id=%tile.railcraft.machine.alpha,data=12,stdrot=true,face0-3=0:railcraft/blast.furnace,face4=1:railcraft/blast.furnace,face5=0:railcraft/blast.furnace
+block:id=%tile.railcraft.machine.alpha,data=13,stdrot=true,face0=0:railcraft/engraving.bench,face1=1:railcraft/engraving.bench,face2-5=3:railcraft/engraving.bench
+block:id=%tile.railcraft.machine.alpha,data=14,stdrot=true,face0-1=0:railcraft/tank.water,face2-5=1:railcraft/tank.water
+block:id=%tile.railcraft.machine.alpha,data=15,stdrot=true,face0=3:railcraft/rock.crusher,face1=11:railcraft/rock.crusher,face2-3=3:railcraft/rock.crusher,face4=7:railcraft/rock.crusher,face5=3:railcraft/rock.crusher
+# %tile.railcraft.machine.beta:* (tile.railcraft.machine.beta), render=67(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.machine.BlockMachine
+block:id=%tile.railcraft.machine.beta,data=0,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/tank.iron.wall,face2-5=1:railcraft/tank.iron.wall
+block:id=%tile.railcraft.machine.beta,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/tank.iron.gauge
+block:id=%tile.railcraft.machine.beta,data=2,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/tank.iron.valve,face2-5=1:railcraft/tank.iron.valve
+block:id=%tile.railcraft.machine.beta,data=3,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/boiler.tank.pressure.low,face2-5=1:railcraft/boiler.tank.pressure.low
+block:id=%tile.railcraft.machine.beta,data=4,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/boiler.tank.pressure.high,face2-5=1:railcraft/boiler.tank.pressure.high
+block:id=%tile.railcraft.machine.beta,data=5,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/boiler.firebox.solid,face2-5=1:railcraft/boiler.firebox.solid
+block:id=%tile.railcraft.machine.beta,data=6,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/boiler.firebox.liquid,face2-5=1:railcraft/boiler.firebox.liquid
+block:id=%tile.railcraft.machine.beta,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/engine.steam.hobby
+block:id=%tile.railcraft.machine.beta,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/engine.steam.low
+block:id=%tile.railcraft.machine.beta,data=9,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/engine.steam.high
+block:id=%tile.railcraft.machine.beta,data=10,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/anchor.sentinel,face2-5=1:railcraft/anchor.sentinel
+block:id=%tile.railcraft.machine.beta,data=11,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/chest.void
+block:id=%tile.railcraft.machine.beta,data=13,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/tank.steel.wall,face2-5=1:railcraft/tank.steel.wall
+block:id=%tile.railcraft.machine.beta,data=14,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/tank.steel.gauge
+block:id=%tile.railcraft.machine.beta,data=15,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/tank.steel.valve,face2-5=1:railcraft/tank.steel.valve
+# %tile.railcraft.machine.gamma:* (tile.railcraft.machine.gamma), render=0(STANDARD), opaque=false,cls=mods.railcraft.common.blocks.machine.BlockMachine
+block:id=%tile.railcraft.machine.gamma,data=0,stdrot=true,face0=2:railcraft/loader.item,face1=0:railcraft/loader.item,face2-5=1:railcraft/loader.item
+block:id=%tile.railcraft.machine.gamma,data=1,stdrot=true,face0=0:railcraft/unloader.item,face1=2:railcraft/unloader.item,face2-5=1:railcraft/unloader.item
+block:id=%tile.railcraft.machine.gamma,data=2,stdrot=true,face0-1=0:railcraft/loader.item.advanced,face2=1:railcraft/loader.item.advanced,face3=2:railcraft/loader.item.advanced,face4-5=1:railcraft/loader.item.advanced
+block:id=%tile.railcraft.machine.gamma,data=3,stdrot=true,face0-1=0:railcraft/unloader.item.advanced,face2=1:railcraft/unloader.item.advanced,face3=2:railcraft/unloader.item.advanced,face4-5=1:railcraft/unloader.item.advanced
+block:id=%tile.railcraft.machine.gamma,data=4,stdrot=true,face0=2:railcraft/loader.liquid,face1=0:railcraft/loader.liquid,face2-5=1:railcraft/loader.liquid
+block:id=%tile.railcraft.machine.gamma,data=5,stdrot=true,face0=0:railcraft/unloader.liquid,face1=2:railcraft/unloader.liquid,face2-5=1:railcraft/unloader.liquid
+block:id=%tile.railcraft.machine.gamma,data=6,stdrot=true,face0-1=0:railcraft/loader.energy,face2=1:railcraft/loader.energy,face3=2:railcraft/loader.energy,face4-5=1:railcraft/loader.energy
+block:id=%tile.railcraft.machine.gamma,data=7,stdrot=true,face0-1=0:railcraft/unloader.energy,face2=1:railcraft/unloader.energy,face3=2:railcraft/unloader.energy,face4-5=1:railcraft/unloader.energy
+block:id=%tile.railcraft.machine.gamma,data=8,stdrot=true,face0-1=0:railcraft/dispenser.cart,face2=1:railcraft/dispenser.cart,face3=2:railcraft/dispenser.cart,face4-5=1:railcraft/dispenser.cart
+block:id=%tile.railcraft.machine.gamma,data=9,stdrot=true,face0-1=0:railcraft/dispenser.train,face2=1:railcraft/dispenser.train,face3=2:railcraft/dispenser.train,face4-5=1:railcraft/dispenser.train
+block:id=%tile.railcraft.machine.gamma,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0=2:railcraft/loader.item,face1=0:railcraft/loader.item,face2-5=1:railcraft/loader.item
 
-# block.track:* (tile.railcraft.track), render=56(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.tracks.BlockTrack
-block:id=block.track,data=0,data=1,data=2,data=3,data=4,data=5,patch0=0:track0,patch1=0:track1,patch2=0:track2,patch3=0:track3,patch4=0:track4,patch5=0:track5,patch6=0:track6,patch7=0:track7,patch8=0:track8,patch9=0:track9,patch10=0:track10,patch11=0:track11,patch12=0:track12,patch13=0:track13,patch14=0:track14,patch15=0:track15,patch16=0:track16,patch17=0:track17,patch18=0:track18,patch19=0:track19,patch20=0:track20,patch21=0:track21,patch22=0:track22,patch24=0:track24,patch25=0:track25,patch26=0:track26,patch27=0:track27,patch28=0:track28,patch29=0:track29,patch30=0:track30,patch31=0:track31,patch32=0:track32,patch33=0:track33,patch34=0:track34,patch35=0:track35,patch36=0:track36,patch37=0:track37,patch38=0:track38,patch39=0:track39,patch40=0:track40,patch41=0:track41,transparency=TRANSPARENT
-block:id=block.track,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,patch0=1:track0,patch1=1:track1,patch2=1:track2,patch3=1:track3,patch4=1:track4,patch5=1:track5,patch6=0:track6,patch7=1:track7,patch8=1:track8,patch9=0:track9,patch10=1:track10,patch11=0:track11,patch12=1:track12,patch13=1:track13,patch14=0:track14,patch15=1:track15,patch16=1:track16,patch17=1:track17,patch18=1:track18,patch19=1:track19,patch20=1:track20,patch21=1:track21,patch22=1:track22,patch24=1:track24,patch25=1:track25,patch26=0:track26,patch27=1:track27,patch28=1:track28,patch29=0:track29,patch30=1:track30,patch31=1:track31,patch32=1:track32,patch33=1:track33,patch34=1:track34,patch35=1:track35,patch36=1:track36,patch37=1:track37,patch38=1:track38,patch39=1:track39,patch40=1:track40,patch41=1:track41,transparency=TRANSPARENT
+# %tile.railcraft.track:* (tile.railcraft.track), render=56(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.tracks.BlockTrack
+block:id=%tile.railcraft.track,data=0,data=1,data=2,data=3,data=4,data=5,patch0=0:track0,patch1=0:track1,patch2=0:track2,patch3=0:track3,patch4=0:track4,patch5=0:track5,patch6=0:track6,patch7=0:track7,patch8=0:track8,patch9=0:track9,patch10=0:track10,patch11=0:track11,patch12=0:track12,patch13=0:track13,patch14=0:track14,patch15=0:track15,patch16=0:track16,patch17=0:track17,patch18=0:track18,patch19=0:track19,patch20=0:track20,patch21=0:track21,patch22=0:track22,patch24=0:track24,patch25=0:track25,patch26=0:track26,patch27=0:track27,patch28=0:track28,patch29=0:track29,patch30=0:track30,patch31=0:track31,patch32=0:track32,patch33=0:track33,patch34=0:track34,patch35=0:track35,patch36=0:track36,patch37=0:track37,patch38=0:track38,patch39=0:track39,patch40=0:track40,patch41=0:track41,transparency=TRANSPARENT
+block:id=%tile.railcraft.track,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,patch0=1:track0,patch1=1:track1,patch2=1:track2,patch3=1:track3,patch4=1:track4,patch5=1:track5,patch6=0:track6,patch7=1:track7,patch8=1:track8,patch9=0:track9,patch10=1:track10,patch11=0:track11,patch12=1:track12,patch13=1:track13,patch14=0:track14,patch15=1:track15,patch16=1:track16,patch17=1:track17,patch18=1:track18,patch19=1:track19,patch20=1:track20,patch21=1:track21,patch22=1:track22,patch24=1:track24,patch25=1:track25,patch26=0:track26,patch27=1:track27,patch28=1:track28,patch29=0:track29,patch30=1:track30,patch31=1:track31,patch32=1:track32,patch33=1:track33,patch34=1:track34,patch35=1:track35,patch36=1:track36,patch37=1:track37,patch38=1:track38,patch39=1:track39,patch40=1:track40,patch41=1:track41,transparency=TRANSPARENT
 
-# block.elevator:* (tile.railcraft.track.elevator), render=57(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.tracks.BlockTrackElevator
-block:id=block.elevator,data=0,data=1,data=2,data=3,data=4,data=5,data=6,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=1:railcraft/tracks/track.elevator
-block:id=block.elevator,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/tracks/track.elevator
-# block.signal:* (tile.railcraft.signal), render=58(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.signals.BlockSignal
-block:id=block.signal,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.interlock
-block:id=block.signal,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.dual
-block:id=block.signal,data=2,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.switch.motor
-block:id=block.signal,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.single
-block:id=block.signal,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.switch.lever
-block:id=block.signal,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.switch.routing
-block:id=block.signal,data=6,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.sequencer
-block:id=block.signal,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.capacitor
-block:id=block.signal,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.receiver
-block:id=block.signal,data=9,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.controller
-block:id=block.signal,data=10,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.single
-block:id=block.signal,data=11,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.dual
-block:id=block.signal,data=12,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.block.relay
-block:id=block.signal,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.switch.lever
-# block.cube:* (tile.railcraft.cube), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.cube.BlockCube
-block:id=block.cube,data=0,stdrot=true,face0-5=0:railcraft/cube.coke
-block:id=block.cube,data=1,stdrot=true,face0-5=0:railcraft/concrete
-block:id=block.cube,data=2,stdrot=true,face0-5=0:railcraft/cube.steel
-block:id=block.cube,data=3,stdrot=true,face0-5=0:railcraft/cube.brick.infernal
-block:id=block.cube,data=4,stdrot=true,face0-5=0:railcraft/cube.crushed.obsidian
-block:id=block.cube,data=5,stdrot=true,face0-5=0:railcraft/cube.brick.sandy
-block:id=block.cube,data=6,stdrot=true,face0-5=0:railcraft/cube.stone.abyssal
-block:id=block.cube,data=7,stdrot=true,face0-5=0:railcraft/cube.stone.quarried
-block:id=block.cube,data=8,stdrot=true,face0-5=0:railcraft/post.wood
-block:id=block.cube,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/concrete
-# block.ore:* (tile.railcraft.ore), render=68(CUSTOM), opaque=true,cls=mods.railcraft.common.blocks.ore.BlockOre
-block:id=block.ore,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stone
-block:id=block.ore,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/sandstone_bottom
-block:id=block.ore,data=2,data=3,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/cube.stone.abyssal
-block:id=block.ore,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/netherrack
-block:id=block.ore,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stone
-# block.post:* (tile.railcraft.post), render=59(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.post.BlockPost
-block:id=block.post,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/post.wood
-block:id=block.post,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/concrete
-block:id=block.post,data=2,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/post.metal
-block:id=block.post,data=4,data=5,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/post.wood
-# block.post.metal:* (tile.railcraft.post.metal), render=60(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.post.BlockPostMetal
-block:id=block.post.metal,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/post.metal.painted
-block:id=block.post.metal,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=1:railcraft/post.metal.painted
-block:id=block.post.metal,data=2,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/post.metal.painted
-block:id=block.post.metal,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=3:railcraft/post.metal.painted
-block:id=block.post.metal,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=4:railcraft/post.metal.painted
-block:id=block.post.metal,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=5:railcraft/post.metal.painted
-block:id=block.post.metal,data=6,stdrot=true,transparency=TRANSPARENT,face0-5=6:railcraft/post.metal.painted
-block:id=block.post.metal,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=7:railcraft/post.metal.painted
-block:id=block.post.metal,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=8:railcraft/post.metal.painted
-block:id=block.post.metal,data=9,stdrot=true,transparency=TRANSPARENT,face0-5=9:railcraft/post.metal.painted
-block:id=block.post.metal,data=10,stdrot=true,transparency=TRANSPARENT,face0-5=10:railcraft/post.metal.painted
-block:id=block.post.metal,data=11,stdrot=true,transparency=TRANSPARENT,face0-5=11:railcraft/post.metal.painted
-block:id=block.post.metal,data=12,stdrot=true,transparency=TRANSPARENT,face0-5=12:railcraft/post.metal.painted
-block:id=block.post.metal,data=13,stdrot=true,transparency=TRANSPARENT,face0-5=13:railcraft/post.metal.painted
-block:id=block.post.metal,data=14,stdrot=true,transparency=TRANSPARENT,face0-5=14:railcraft/post.metal.painted
-block:id=block.post.metal,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=15:railcraft/post.metal.painted
-# block.wall.alpha:* (tile.railcraft.wall.alpha), render=61(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.wall.BlockRailcraftWall
-block:id=block.wall.alpha,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.infernal
-block:id=block.wall.alpha,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.sandy
-block:id=block.wall.alpha,data=2,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/concrete
-block:id=block.wall.alpha,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/snow
-block:id=block.wall.alpha,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/ice
-block:id=block.wall.alpha,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stonebrick
-block:id=block.wall.alpha,data=6,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stonebrick_mossy
-block:id=block.wall.alpha,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stonebrick_cracked
-block:id=block.wall.alpha,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stonebrick_carved
-block:id=block.wall.alpha,data=9,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/nether_brick
-block:id=block.wall.alpha,data=10,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/brick
-block:id=block.wall.alpha,data=11,stdrot=true,transparency=TRANSPARENT,face0=0:minecraft/sandstone_bottom,face1=0:minecraft/sandstone_top,face2-5=0:minecraft/sandstone_normal
-block:id=block.wall.alpha,data=12,stdrot=true,transparency=TRANSPARENT,face0-1=0:minecraft/sandstone_top,face2-5=0:minecraft/sandstone_carved
-block:id=block.wall.alpha,data=13,stdrot=true,transparency=TRANSPARENT,face0-1=0:minecraft/sandstone_top,face2-5=0:minecraft/sandstone_smooth
-block:id=block.wall.alpha,data=14,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/obsidian
-block:id=block.wall.alpha,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.frostbound
-# block.worldlogic:* (tile.railcraft.worldlogic), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.ore.BlockWorldLogic
-block:id=block.worldlogic,data=*,stdrot=true,face0-5=0:minecraft/bedrock
-# block.wall.beta:* (tile.railcraft.wall.beta), render=62(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.wall.BlockRailcraftWall
-block:id=block.wall.beta,data=0,stdrot=true,transparency=TRANSPARENT,face0=0:minecraft/quartz_block_bottom,face1=0:minecraft/quartz_block_top,face2-5=0:minecraft/quartz_block_side
-block:id=block.wall.beta,data=1,stdrot=true,transparency=TRANSPARENT,face0-1=0:minecraft/quartz_block_chiseled_top,face2-5=0:minecraft/quartz_block_chiseled
-block:id=block.wall.beta,data=2,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/iron_block
-block:id=block.wall.beta,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/gold_block
-block:id=block.wall.beta,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/diamond_block
-block:id=block.wall.beta,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.abyssal
-block:id=block.wall.beta,data=6,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.quarried
-block:id=block.wall.beta,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.bloodstained
-block:id=block.wall.beta,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.bleachedbone
-block:id=block.wall.beta,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0=0:minecraft/quartz_block_bottom,face1=0:minecraft/quartz_block_top,face2-5=0:minecraft/quartz_block_side
+# %tile.railcraft.track.elevator:* (tile.railcraft.track.elevator), render=57(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.tracks.BlockTrackElevator
+block:id=%tile.railcraft.track.elevator,data=0,data=1,data=2,data=3,data=4,data=5,data=6,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=1:railcraft/tracks/track.elevator
+block:id=%tile.railcraft.track.elevator,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/tracks/track.elevator
+# %tile.railcraft.signal:* (tile.railcraft.signal), render=58(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.signals.BlockSignal
+block:id=%tile.railcraft.signal,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.interlock
+block:id=%tile.railcraft.signal,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.dual
+block:id=%tile.railcraft.signal,data=2,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.switch.motor
+block:id=%tile.railcraft.signal,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.single
+block:id=%tile.railcraft.signal,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.switch.lever
+block:id=%tile.railcraft.signal,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.switch.routing
+block:id=%tile.railcraft.signal,data=6,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.sequencer
+block:id=%tile.railcraft.signal,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.capacitor
+block:id=%tile.railcraft.signal,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.receiver
+block:id=%tile.railcraft.signal,data=9,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.controller
+block:id=%tile.railcraft.signal,data=10,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.single
+block:id=%tile.railcraft.signal,data=11,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.dual
+block:id=%tile.railcraft.signal,data=12,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.box.block.relay
+block:id=%tile.railcraft.signal,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/signal.switch.lever
+# %tile.railcraft.cube:* (tile.railcraft.cube), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.cube.BlockCube
+block:id=%tile.railcraft.cube,data=0,stdrot=true,face0-5=0:railcraft/cube.coke
+block:id=%tile.railcraft.cube,data=1,stdrot=true,face0-5=0:railcraft/concrete
+block:id=%tile.railcraft.cube,data=2,stdrot=true,face0-5=0:railcraft/cube.steel
+block:id=%tile.railcraft.cube,data=3,stdrot=true,face0-5=0:railcraft/cube.brick.infernal
+block:id=%tile.railcraft.cube,data=4,stdrot=true,face0-5=0:railcraft/cube.crushed.obsidian
+block:id=%tile.railcraft.cube,data=5,stdrot=true,face0-5=0:railcraft/cube.brick.sandy
+block:id=%tile.railcraft.cube,data=6,stdrot=true,face0-5=0:railcraft/cube.stone.abyssal
+block:id=%tile.railcraft.cube,data=7,stdrot=true,face0-5=0:railcraft/cube.stone.quarried
+block:id=%tile.railcraft.cube,data=8,stdrot=true,face0-5=0:railcraft/post.wood
+block:id=%tile.railcraft.cube,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/concrete
+# %tile.railcraft.ore:* (tile.railcraft.ore), render=68(CUSTOM), opaque=true,cls=mods.railcraft.common.blocks.ore.BlockOre
+block:id=%tile.railcraft.ore,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stone
+block:id=%tile.railcraft.ore,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/sandstone_bottom
+block:id=%tile.railcraft.ore,data=2,data=3,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/cube.stone.abyssal
+block:id=%tile.railcraft.ore,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/netherrack
+block:id=%tile.railcraft.ore,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stone
+# %tile.railcraft.post:* (tile.railcraft.post), render=59(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.post.BlockPost
+block:id=%tile.railcraft.post,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/post.wood
+block:id=%tile.railcraft.post,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/concrete
+block:id=%tile.railcraft.post,data=2,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/post.metal
+block:id=%tile.railcraft.post,data=4,data=5,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/post.wood
+# %tile.railcraft.post.metal:* (tile.railcraft.post.metal), render=60(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.post.BlockPostMetal
+block:id=%tile.railcraft.post.metal,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=1:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=2,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=3:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=4:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=5:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=6,stdrot=true,transparency=TRANSPARENT,face0-5=6:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=7:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=8:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=9,stdrot=true,transparency=TRANSPARENT,face0-5=9:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=10,stdrot=true,transparency=TRANSPARENT,face0-5=10:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=11,stdrot=true,transparency=TRANSPARENT,face0-5=11:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=12,stdrot=true,transparency=TRANSPARENT,face0-5=12:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=13,stdrot=true,transparency=TRANSPARENT,face0-5=13:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=14,stdrot=true,transparency=TRANSPARENT,face0-5=14:railcraft/post.metal.painted
+block:id=%tile.railcraft.post.metal,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=15:railcraft/post.metal.painted
+# %tile.railcraft.wall.alpha:* (tile.railcraft.wall.alpha), render=61(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.wall.BlockRailcraftWall
+block:id=%tile.railcraft.wall.alpha,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.infernal
+block:id=%tile.railcraft.wall.alpha,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.sandy
+block:id=%tile.railcraft.wall.alpha,data=2,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/concrete
+block:id=%tile.railcraft.wall.alpha,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/snow
+block:id=%tile.railcraft.wall.alpha,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/ice
+block:id=%tile.railcraft.wall.alpha,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stonebrick
+block:id=%tile.railcraft.wall.alpha,data=6,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stonebrick_mossy
+block:id=%tile.railcraft.wall.alpha,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stonebrick_cracked
+block:id=%tile.railcraft.wall.alpha,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stonebrick_carved
+block:id=%tile.railcraft.wall.alpha,data=9,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/nether_brick
+block:id=%tile.railcraft.wall.alpha,data=10,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/brick
+block:id=%tile.railcraft.wall.alpha,data=11,stdrot=true,transparency=TRANSPARENT,face0=0:minecraft/sandstone_bottom,face1=0:minecraft/sandstone_top,face2-5=0:minecraft/sandstone_normal
+block:id=%tile.railcraft.wall.alpha,data=12,stdrot=true,transparency=TRANSPARENT,face0-1=0:minecraft/sandstone_top,face2-5=0:minecraft/sandstone_carved
+block:id=%tile.railcraft.wall.alpha,data=13,stdrot=true,transparency=TRANSPARENT,face0-1=0:minecraft/sandstone_top,face2-5=0:minecraft/sandstone_smooth
+block:id=%tile.railcraft.wall.alpha,data=14,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/obsidian
+block:id=%tile.railcraft.wall.alpha,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.frostbound
+# %tile.railcraft.worldlogic:* (tile.railcraft.worldlogic), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.ore.BlockWorldLogic
+block:id=%tile.railcraft.worldlogic,data=*,stdrot=true,face0-5=0:minecraft/bedrock
+# %tile.railcraft.wall.beta:* (tile.railcraft.wall.beta), render=62(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.wall.BlockRailcraftWall
+block:id=%tile.railcraft.wall.beta,data=0,stdrot=true,transparency=TRANSPARENT,face0=0:minecraft/quartz_block_bottom,face1=0:minecraft/quartz_block_top,face2-5=0:minecraft/quartz_block_side
+block:id=%tile.railcraft.wall.beta,data=1,stdrot=true,transparency=TRANSPARENT,face0-1=0:minecraft/quartz_block_chiseled_top,face2-5=0:minecraft/quartz_block_chiseled
+block:id=%tile.railcraft.wall.beta,data=2,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/iron_block
+block:id=%tile.railcraft.wall.beta,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/gold_block
+block:id=%tile.railcraft.wall.beta,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/diamond_block
+block:id=%tile.railcraft.wall.beta,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.abyssal
+block:id=%tile.railcraft.wall.beta,data=6,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.quarried
+block:id=%tile.railcraft.wall.beta,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.bloodstained
+block:id=%tile.railcraft.wall.beta,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/brick.bleachedbone
+block:id=%tile.railcraft.wall.beta,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0=0:minecraft/quartz_block_bottom,face1=0:minecraft/quartz_block_top,face2-5=0:minecraft/quartz_block_side
 
-# block.stair:* (tile.railcraft.stair), render=63(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.stairs.BlockRailcraftStairs
-block:id=block.stair,data=*,patch0=0:railcraft/brick.sandy,patch1=0:railcraft/brick.infernal,patch2=0:railcraft/concrete,patch3=0:minecraft/snow,,patch4=12000:minecraft/ice,patch5=0:minecraft/iron_block,patch6=0:minecraft/gold_block,patch7=0:minecraft/diamond_block,patch8=0:railcraft/brick.frostbound,patch9=0:railcraft/brick.quarried,patch10=0:railcraft/brick.bleachedbone,patch11=0:railcraft/brick.bloodstained,patch12=0:railcraft/brick.abyssal,patch13=1:railcraft/brick.sandy,patch14=1:railcraft/brick.infernal,patch15=1:railcraft/brick.frostbound,patch16=1:railcraft/brick.quarried,patch17=1:railcraft/brick.bleachedbone,patch18=1:railcraft/brick.bloodstained,patch19=1:railcraft/brick.abyssal,patch20=2:railcraft/brick.sandy,patch21=2:railcraft/brick.infernal,patch22=2:railcraft/brick.frostbound,patch23=2:railcraft/brick.quarried,patch24=2:railcraft/brick.bleachedbone,patch25=2:railcraft/brick.bloodstained,patch26=2:railcraft/brick.abyssal,patch27=5:railcraft/brick.sandy,patch28=5:railcraft/brick.infernal,patch29=5:railcraft/brick.frostbound,patch30=5:railcraft/brick.quarried,patch31=5:railcraft/brick.bleachedbone,patch32=5:railcraft/brick.bloodstained,patch33=5:railcraft/brick.abyssal,patch34=5:railcraft/brick.nether,patch35=0:railcraft/post.wood,transparency=SEMITRANSPARENT
+# %tile.railcraft.stair:* (tile.railcraft.stair), render=63(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.stairs.BlockRailcraftStairs
+block:id=%tile.railcraft.stair,data=*,patch0=0:railcraft/brick.sandy,patch1=0:railcraft/brick.infernal,patch2=0:railcraft/concrete,patch3=0:minecraft/snow,,patch4=12000:minecraft/ice,patch5=0:minecraft/iron_block,patch6=0:minecraft/gold_block,patch7=0:minecraft/diamond_block,patch8=0:railcraft/brick.frostbound,patch9=0:railcraft/brick.quarried,patch10=0:railcraft/brick.bleachedbone,patch11=0:railcraft/brick.bloodstained,patch12=0:railcraft/brick.abyssal,patch13=1:railcraft/brick.sandy,patch14=1:railcraft/brick.infernal,patch15=1:railcraft/brick.frostbound,patch16=1:railcraft/brick.quarried,patch17=1:railcraft/brick.bleachedbone,patch18=1:railcraft/brick.bloodstained,patch19=1:railcraft/brick.abyssal,patch20=2:railcraft/brick.sandy,patch21=2:railcraft/brick.infernal,patch22=2:railcraft/brick.frostbound,patch23=2:railcraft/brick.quarried,patch24=2:railcraft/brick.bleachedbone,patch25=2:railcraft/brick.bloodstained,patch26=2:railcraft/brick.abyssal,patch27=5:railcraft/brick.sandy,patch28=5:railcraft/brick.infernal,patch29=5:railcraft/brick.frostbound,patch30=5:railcraft/brick.quarried,patch31=5:railcraft/brick.bleachedbone,patch32=5:railcraft/brick.bloodstained,patch33=5:railcraft/brick.abyssal,patch34=5:railcraft/brick.nether,patch35=0:railcraft/post.wood,transparency=SEMITRANSPARENT
 
-# block.slab:* (tile.railcraft.slab), render=64(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.slab.BlockRailcraftSlab
-block:id=block.slab,data=*,patch0=0:railcraft/brick.sandy,patch1=0:railcraft/brick.infernal,patch2=0:railcraft/concrete,patch3=0:minecraft/snow,,patch4=12000:minecraft/ice,patch5=0:minecraft/iron_block,patch6=0:minecraft/gold_block,patch7=0:minecraft/diamond_block,patch8=0:railcraft/brick.frostbound,patch9=0:railcraft/brick.quarried,patch10=0:railcraft/brick.bleachedbone,patch11=0:railcraft/brick.bloodstained,patch12=0:railcraft/brick.abyssal,patch13=1:railcraft/brick.sandy,patch14=1:railcraft/brick.infernal,patch15=1:railcraft/brick.frostbound,patch16=1:railcraft/brick.quarried,patch17=1:railcraft/brick.bleachedbone,patch18=1:railcraft/brick.bloodstained,patch19=1:railcraft/brick.abyssal,patch20=2:railcraft/brick.sandy,patch21=2:railcraft/brick.infernal,patch22=2:railcraft/brick.frostbound,patch23=2:railcraft/brick.quarried,patch24=2:railcraft/brick.bleachedbone,patch25=2:railcraft/brick.bloodstained,patch26=2:railcraft/brick.abyssal,patch27=5:railcraft/brick.sandy,patch28=5:railcraft/brick.infernal,patch29=5:railcraft/brick.frostbound,patch30=5:railcraft/brick.quarried,patch31=5:railcraft/brick.bleachedbone,patch32=5:railcraft/brick.bloodstained,patch33=5:railcraft/brick.abyssal,patch34=5:railcraft/brick.nether,patch35=0:railcraft/post.wood,transparency=SEMITRANSPARENT
+# %tile.railcraft.slab:* (tile.railcraft.slab), render=64(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.slab.BlockRailcraftSlab
+block:id=%tile.railcraft.slab,data=*,patch0=0:railcraft/brick.sandy,patch1=0:railcraft/brick.infernal,patch2=0:railcraft/concrete,patch3=0:minecraft/snow,,patch4=12000:minecraft/ice,patch5=0:minecraft/iron_block,patch6=0:minecraft/gold_block,patch7=0:minecraft/diamond_block,patch8=0:railcraft/brick.frostbound,patch9=0:railcraft/brick.quarried,patch10=0:railcraft/brick.bleachedbone,patch11=0:railcraft/brick.bloodstained,patch12=0:railcraft/brick.abyssal,patch13=1:railcraft/brick.sandy,patch14=1:railcraft/brick.infernal,patch15=1:railcraft/brick.frostbound,patch16=1:railcraft/brick.quarried,patch17=1:railcraft/brick.bleachedbone,patch18=1:railcraft/brick.bloodstained,patch19=1:railcraft/brick.abyssal,patch20=2:railcraft/brick.sandy,patch21=2:railcraft/brick.infernal,patch22=2:railcraft/brick.frostbound,patch23=2:railcraft/brick.quarried,patch24=2:railcraft/brick.bleachedbone,patch25=2:railcraft/brick.bloodstained,patch26=2:railcraft/brick.abyssal,patch27=5:railcraft/brick.sandy,patch28=5:railcraft/brick.infernal,patch29=5:railcraft/brick.frostbound,patch30=5:railcraft/brick.quarried,patch31=5:railcraft/brick.bleachedbone,patch32=5:railcraft/brick.bloodstained,patch33=5:railcraft/brick.abyssal,patch34=5:railcraft/brick.nether,patch35=0:railcraft/post.wood,transparency=SEMITRANSPARENT
 
-# block.brick.abyssal:* (tile.railcraft.brick.abyssal), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
-block:id=block.brick.abyssal,data=0,stdrot=true,face0-5=0:railcraft/brick.abyssal
-block:id=block.brick.abyssal,data=1,stdrot=true,face0-5=1:railcraft/brick.abyssal
-block:id=block.brick.abyssal,data=2,stdrot=true,face0-5=2:railcraft/brick.abyssal
-block:id=block.brick.abyssal,data=3,stdrot=true,face0-5=3:railcraft/brick.abyssal
-block:id=block.brick.abyssal,data=4,stdrot=true,face0-5=4:railcraft/brick.abyssal
-block:id=block.brick.abyssal,data=5,stdrot=true,face0-5=5:railcraft/brick.abyssal
-block:id=block.brick.abyssal,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.abyssal
-# block.brick.infernal:* (tile.railcraft.brick.infernal), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
-block:id=block.brick.infernal,data=0,stdrot=true,face0-5=0:railcraft/brick.infernal
-block:id=block.brick.infernal,data=1,stdrot=true,face0-5=1:railcraft/brick.infernal
-block:id=block.brick.infernal,data=2,stdrot=true,face0-5=2:railcraft/brick.infernal
-block:id=block.brick.infernal,data=3,stdrot=true,face0-5=3:railcraft/brick.infernal
-block:id=block.brick.infernal,data=4,stdrot=true,face0-5=4:railcraft/brick.infernal
-block:id=block.brick.infernal,data=5,stdrot=true,face0-5=5:railcraft/brick.infernal
-block:id=block.brick.infernal,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.infernal
-# block.brick.bloodstained:* (tile.railcraft.brick.bloodstained), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
-block:id=block.brick.bloodstained,data=0,stdrot=true,face0-5=0:railcraft/brick.bloodstained
-block:id=block.brick.bloodstained,data=1,stdrot=true,face0-5=1:railcraft/brick.bloodstained
-block:id=block.brick.bloodstained,data=2,stdrot=true,face0-5=2:railcraft/brick.bloodstained
-block:id=block.brick.bloodstained,data=3,stdrot=true,face0-5=3:railcraft/brick.bloodstained
-block:id=block.brick.bloodstained,data=4,stdrot=true,face0-5=4:railcraft/brick.bloodstained
-block:id=block.brick.bloodstained,data=5,stdrot=true,face0-5=5:railcraft/brick.bloodstained
-block:id=block.brick.bloodstained,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.bloodstained
-# block.brick.sandy:* (tile.railcraft.brick.sandy), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
-block:id=block.brick.sandy,data=0,stdrot=true,face0-5=0:railcraft/brick.sandy
-block:id=block.brick.sandy,data=1,stdrot=true,face0-5=1:railcraft/brick.sandy
-block:id=block.brick.sandy,data=2,stdrot=true,face0-5=2:railcraft/brick.sandy
-block:id=block.brick.sandy,data=3,stdrot=true,face0-5=3:railcraft/brick.sandy
-block:id=block.brick.sandy,data=4,stdrot=true,face0-5=4:railcraft/brick.sandy
-block:id=block.brick.sandy,data=5,stdrot=true,face0-5=5:railcraft/brick.sandy
-block:id=block.brick.sandy,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.sandy
-# block.brick.bleachedbone:* (tile.railcraft.brick.bleachedbone), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
-block:id=block.brick.bleachedbone,data=0,stdrot=true,face0-5=0:railcraft/brick.bleachedbone
-block:id=block.brick.bleachedbone,data=1,stdrot=true,face0-5=1:railcraft/brick.bleachedbone
-block:id=block.brick.bleachedbone,data=2,stdrot=true,face0-5=2:railcraft/brick.bleachedbone
-block:id=block.brick.bleachedbone,data=3,stdrot=true,face0-5=3:railcraft/brick.bleachedbone
-block:id=block.brick.bleachedbone,data=4,stdrot=true,face0-5=4:railcraft/brick.bleachedbone
-block:id=block.brick.bleachedbone,data=5,stdrot=true,face0-5=5:railcraft/brick.bleachedbone
-block:id=block.brick.bleachedbone,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.bleachedbone
-# block.brick.quarried:* (tile.railcraft.brick.quarried), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
-block:id=block.brick.quarried,data=0,stdrot=true,face0-5=0:railcraft/brick.quarried
-block:id=block.brick.quarried,data=1,stdrot=true,face0-5=1:railcraft/brick.quarried
-block:id=block.brick.quarried,data=2,stdrot=true,face0-5=2:railcraft/brick.quarried
-block:id=block.brick.quarried,data=3,stdrot=true,face0-5=3:railcraft/brick.quarried
-block:id=block.brick.quarried,data=4,stdrot=true,face0-5=4:railcraft/brick.quarried
-block:id=block.brick.quarried,data=5,stdrot=true,face0-5=5:railcraft/brick.quarried
-block:id=block.brick.quarried,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.quarried
-# block.brick.frostbound:* (tile.railcraft.brick.frostbound), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
-block:id=block.brick.frostbound,data=0,stdrot=true,face0-5=0:railcraft/brick.frostbound
-block:id=block.brick.frostbound,data=1,stdrot=true,face0-5=1:railcraft/brick.frostbound
-block:id=block.brick.frostbound,data=2,stdrot=true,face0-5=2:railcraft/brick.frostbound
-block:id=block.brick.frostbound,data=3,stdrot=true,face0-5=3:railcraft/brick.frostbound
-block:id=block.brick.frostbound,data=4,stdrot=true,face0-5=4:railcraft/brick.frostbound
-block:id=block.brick.frostbound,data=5,stdrot=true,face0-5=5:railcraft/brick.frostbound
-block:id=block.brick.frostbound,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.frostbound
+# %tile.railcraft.brick.abyssal:* (tile.railcraft.brick.abyssal), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
+block:id=%tile.railcraft.brick.abyssal,data=0,stdrot=true,face0-5=0:railcraft/brick.abyssal
+block:id=%tile.railcraft.brick.abyssal,data=1,stdrot=true,face0-5=1:railcraft/brick.abyssal
+block:id=%tile.railcraft.brick.abyssal,data=2,stdrot=true,face0-5=2:railcraft/brick.abyssal
+block:id=%tile.railcraft.brick.abyssal,data=3,stdrot=true,face0-5=3:railcraft/brick.abyssal
+block:id=%tile.railcraft.brick.abyssal,data=4,stdrot=true,face0-5=4:railcraft/brick.abyssal
+block:id=%tile.railcraft.brick.abyssal,data=5,stdrot=true,face0-5=5:railcraft/brick.abyssal
+block:id=%tile.railcraft.brick.abyssal,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.abyssal
+# %tile.railcraft.brick.infernal:* (tile.railcraft.brick.infernal), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
+block:id=%tile.railcraft.brick.infernal,data=0,stdrot=true,face0-5=0:railcraft/brick.infernal
+block:id=%tile.railcraft.brick.infernal,data=1,stdrot=true,face0-5=1:railcraft/brick.infernal
+block:id=%tile.railcraft.brick.infernal,data=2,stdrot=true,face0-5=2:railcraft/brick.infernal
+block:id=%tile.railcraft.brick.infernal,data=3,stdrot=true,face0-5=3:railcraft/brick.infernal
+block:id=%tile.railcraft.brick.infernal,data=4,stdrot=true,face0-5=4:railcraft/brick.infernal
+block:id=%tile.railcraft.brick.infernal,data=5,stdrot=true,face0-5=5:railcraft/brick.infernal
+block:id=%tile.railcraft.brick.infernal,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.infernal
+# %tile.railcraft.brick.bloodstained:* (tile.railcraft.brick.bloodstained), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
+block:id=%tile.railcraft.brick.bloodstained,data=0,stdrot=true,face0-5=0:railcraft/brick.bloodstained
+block:id=%tile.railcraft.brick.bloodstained,data=1,stdrot=true,face0-5=1:railcraft/brick.bloodstained
+block:id=%tile.railcraft.brick.bloodstained,data=2,stdrot=true,face0-5=2:railcraft/brick.bloodstained
+block:id=%tile.railcraft.brick.bloodstained,data=3,stdrot=true,face0-5=3:railcraft/brick.bloodstained
+block:id=%tile.railcraft.brick.bloodstained,data=4,stdrot=true,face0-5=4:railcraft/brick.bloodstained
+block:id=%tile.railcraft.brick.bloodstained,data=5,stdrot=true,face0-5=5:railcraft/brick.bloodstained
+block:id=%tile.railcraft.brick.bloodstained,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.bloodstained
+# %tile.railcraft.brick.sandy:* (tile.railcraft.brick.sandy), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
+block:id=%tile.railcraft.brick.sandy,data=0,stdrot=true,face0-5=0:railcraft/brick.sandy
+block:id=%tile.railcraft.brick.sandy,data=1,stdrot=true,face0-5=1:railcraft/brick.sandy
+block:id=%tile.railcraft.brick.sandy,data=2,stdrot=true,face0-5=2:railcraft/brick.sandy
+block:id=%tile.railcraft.brick.sandy,data=3,stdrot=true,face0-5=3:railcraft/brick.sandy
+block:id=%tile.railcraft.brick.sandy,data=4,stdrot=true,face0-5=4:railcraft/brick.sandy
+block:id=%tile.railcraft.brick.sandy,data=5,stdrot=true,face0-5=5:railcraft/brick.sandy
+block:id=%tile.railcraft.brick.sandy,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.sandy
+# %tile.railcraft.brick.bleachedbone:* (tile.railcraft.brick.bleachedbone), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
+block:id=%tile.railcraft.brick.bleachedbone,data=0,stdrot=true,face0-5=0:railcraft/brick.bleachedbone
+block:id=%tile.railcraft.brick.bleachedbone,data=1,stdrot=true,face0-5=1:railcraft/brick.bleachedbone
+block:id=%tile.railcraft.brick.bleachedbone,data=2,stdrot=true,face0-5=2:railcraft/brick.bleachedbone
+block:id=%tile.railcraft.brick.bleachedbone,data=3,stdrot=true,face0-5=3:railcraft/brick.bleachedbone
+block:id=%tile.railcraft.brick.bleachedbone,data=4,stdrot=true,face0-5=4:railcraft/brick.bleachedbone
+block:id=%tile.railcraft.brick.bleachedbone,data=5,stdrot=true,face0-5=5:railcraft/brick.bleachedbone
+block:id=%tile.railcraft.brick.bleachedbone,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.bleachedbone
+# %tile.railcraft.brick.quarried:* (tile.railcraft.brick.quarried), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
+block:id=%tile.railcraft.brick.quarried,data=0,stdrot=true,face0-5=0:railcraft/brick.quarried
+block:id=%tile.railcraft.brick.quarried,data=1,stdrot=true,face0-5=1:railcraft/brick.quarried
+block:id=%tile.railcraft.brick.quarried,data=2,stdrot=true,face0-5=2:railcraft/brick.quarried
+block:id=%tile.railcraft.brick.quarried,data=3,stdrot=true,face0-5=3:railcraft/brick.quarried
+block:id=%tile.railcraft.brick.quarried,data=4,stdrot=true,face0-5=4:railcraft/brick.quarried
+block:id=%tile.railcraft.brick.quarried,data=5,stdrot=true,face0-5=5:railcraft/brick.quarried
+block:id=%tile.railcraft.brick.quarried,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.quarried
+# %tile.railcraft.brick.frostbound:* (tile.railcraft.brick.frostbound), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick
+block:id=%tile.railcraft.brick.frostbound,data=0,stdrot=true,face0-5=0:railcraft/brick.frostbound
+block:id=%tile.railcraft.brick.frostbound,data=1,stdrot=true,face0-5=1:railcraft/brick.frostbound
+block:id=%tile.railcraft.brick.frostbound,data=2,stdrot=true,face0-5=2:railcraft/brick.frostbound
+block:id=%tile.railcraft.brick.frostbound,data=3,stdrot=true,face0-5=3:railcraft/brick.frostbound
+block:id=%tile.railcraft.brick.frostbound,data=4,stdrot=true,face0-5=4:railcraft/brick.frostbound
+block:id=%tile.railcraft.brick.frostbound,data=5,stdrot=true,face0-5=5:railcraft/brick.frostbound
+block:id=%tile.railcraft.brick.frostbound,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.frostbound
 
-# block.glass:* (tile.railcraft.glass), render=65(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.glass.BlockStrengthGlass
-block:id=block.glass,data=0,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=FFFFFF
-block:id=block.glass,data=1,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=FF6A00
-block:id=block.glass,data=2,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=FF64FF
-block:id=block.glass,data=3,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=7F9AD1
-block:id=block.glass,data=4,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=CFC231
-block:id=block.glass,data=5,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=3FAA36
-block:id=block.glass,data=6,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=E585A0
-block:id=block.glass,data=7,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=444444
-block:id=block.glass,data=8,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=888888
-block:id=block.glass,data=9,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=36809E
-block:id=block.glass,data=10,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=843FBF
-block:id=block.glass,data=11,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=3441A2
-block:id=block.glass,data=12,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=5C3A24
-block:id=block.glass,data=13,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=394C1E
-block:id=block.glass,data=14,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=A33835
-block:id=block.glass,data=15,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=2D2D2D
+# %tile.railcraft.glass:* (tile.railcraft.glass), render=65(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.glass.BlockStrengthGlass
+block:id=%tile.railcraft.glass,data=0,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=FFFFFF
+block:id=%tile.railcraft.glass,data=1,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=FF6A00
+block:id=%tile.railcraft.glass,data=2,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=FF64FF
+block:id=%tile.railcraft.glass,data=3,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=7F9AD1
+block:id=%tile.railcraft.glass,data=4,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=CFC231
+block:id=%tile.railcraft.glass,data=5,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=3FAA36
+block:id=%tile.railcraft.glass,data=6,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=E585A0
+block:id=%tile.railcraft.glass,data=7,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=444444
+block:id=%tile.railcraft.glass,data=8,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=888888
+block:id=%tile.railcraft.glass,data=9,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=36809E
+block:id=%tile.railcraft.glass,data=10,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=843FBF
+block:id=%tile.railcraft.glass,data=11,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=3441A2
+block:id=%tile.railcraft.glass,data=12,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=5C3A24
+block:id=%tile.railcraft.glass,data=13,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=394C1E
+block:id=%tile.railcraft.glass,data=14,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=A33835
+block:id=%tile.railcraft.glass,data=15,patch0=21000:railcraft/glass,patch1=21000:railcraft/glass,patch2=21000:railcraft/glass,patch3=21003:railcraft/glass,patch4=21001:railcraft/glass,patch5=21002:railcraft/glass,patch6=12004:railcraft/glass,layer0-5=6,transparency=TRANSPARENT,colorMult=2D2D2D
 
-# block.brick.nether:* (tile.railcraft.brick.nether), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick$BlockNetherBrick
-block:id=block.brick.nether,data=0,stdrot=true,face0-5=0:railcraft/brick.nether
-block:id=block.brick.nether,data=1,stdrot=true,face0-5=1:railcraft/brick.nether
-block:id=block.brick.nether,data=2,stdrot=true,face0-5=2:railcraft/brick.nether
-block:id=block.brick.nether,data=3,stdrot=true,face0-5=3:railcraft/brick.nether
-block:id=block.brick.nether,data=4,stdrot=true,face0-5=4:railcraft/brick.nether
-block:id=block.brick.nether,data=5,stdrot=true,face0-5=5:railcraft/brick.nether
-block:id=block.brick.nether,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.nether
-# block.firestone.recharge:* (tile.block.firestone.recharge), render=-1(CUSTOM), opaque=false,cls=mods.railcraft.common.items.firestone.BlockFirestoneRecharge
-block:id=block.firestone.recharge,data=*,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/obsidian
-# block.anvil:* (tile.railcraft.block.anvil), render=35(ANVIL), opaque=false,cls=mods.railcraft.common.blocks.anvil.BlockRCAnvil
-block:id=block.anvil,data=*,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/anvil_base
-# block.stonelamp:* (tile.railcraft.stonelamp), render=66(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.lamp.BlockStoneLamp
-block:id=block.stonelamp,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.abyssal
-block:id=block.stonelamp,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.bleachedbone
-block:id=block.stonelamp,data=2,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.bloodstained
-block:id=block.stonelamp,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.frostbound
-block:id=block.stonelamp,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.infernal
-block:id=block.stonelamp,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.nether
-block:id=block.stonelamp,data=6,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.quarried
-block:id=block.stonelamp,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.sandy
-block:id=block.stonelamp,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/sandstone_top
-block:id=block.stonelamp,data=9,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stone_slab_top
-block:id=block.stonelamp,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.abyssal
-# block.fluid.creosote:* (tile.railcraft.block.fluid.creosote), render=40(CUSTOM), opaque=false,cls=mods.railcraft.common.fluids.BlockRailcraftFluid
-block:id=block.fluid.creosote,data=*,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/fluids/creosote_still,face2-5=0:railcraft/fluids/creosote_flow
-# block.fluid.steam:* (tile.railcraft.block.fluid.steam), render=40(CUSTOM), opaque=false,cls=mods.railcraft.common.fluids.BlockRailcraftFluidFinite
-block:id=block.fluid.steam,data=*,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/fluids/steam_still
+# %tile.railcraft.brick.nether:* (tile.railcraft.brick.nether), render=0(STANDARD), opaque=true,cls=mods.railcraft.common.blocks.aesthetics.brick.BlockBrick$BlockNetherBrick
+block:id=%tile.railcraft.brick.nether,data=0,stdrot=true,face0-5=0:railcraft/brick.nether
+block:id=%tile.railcraft.brick.nether,data=1,stdrot=true,face0-5=1:railcraft/brick.nether
+block:id=%tile.railcraft.brick.nether,data=2,stdrot=true,face0-5=2:railcraft/brick.nether
+block:id=%tile.railcraft.brick.nether,data=3,stdrot=true,face0-5=3:railcraft/brick.nether
+block:id=%tile.railcraft.brick.nether,data=4,stdrot=true,face0-5=4:railcraft/brick.nether
+block:id=%tile.railcraft.brick.nether,data=5,stdrot=true,face0-5=5:railcraft/brick.nether
+block:id=%tile.railcraft.brick.nether,data=6,data=7,data=8,data=9,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,face0-5=0:railcraft/brick.nether
+# %tile.railcraft.firestone.recharge:* (tile.block.firestone.recharge), render=-1(CUSTOM), opaque=false,cls=mods.railcraft.common.items.firestone.BlockFirestoneRecharge
+block:id=%tile.railcraft.firestone.recharge,data=*,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/obsidian
+# %tile.railcraft.anvil:* (tile.railcraft.block.anvil), render=35(ANVIL), opaque=false,cls=mods.railcraft.common.blocks.anvil.BlockRCAnvil
+block:id=%tile.railcraft.anvil,data=*,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/anvil_base
+# %tile.railcraft.stonelamp:* (tile.railcraft.stonelamp), render=66(CUSTOM), opaque=false,cls=mods.railcraft.common.blocks.aesthetics.lamp.BlockStoneLamp
+block:id=%tile.railcraft.stonelamp,data=0,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.abyssal
+block:id=%tile.railcraft.stonelamp,data=1,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.bleachedbone
+block:id=%tile.railcraft.stonelamp,data=2,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.bloodstained
+block:id=%tile.railcraft.stonelamp,data=3,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.frostbound
+block:id=%tile.railcraft.stonelamp,data=4,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.infernal
+block:id=%tile.railcraft.stonelamp,data=5,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.nether
+block:id=%tile.railcraft.stonelamp,data=6,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.quarried
+block:id=%tile.railcraft.stonelamp,data=7,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.sandy
+block:id=%tile.railcraft.stonelamp,data=8,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/sandstone_top
+block:id=%tile.railcraft.stonelamp,data=9,stdrot=true,transparency=TRANSPARENT,face0-5=0:minecraft/stone_slab_top
+block:id=%tile.railcraft.stonelamp,data=10,data=11,data=12,data=13,data=14,data=15,stdrot=true,transparency=TRANSPARENT,face0-5=2:railcraft/brick.abyssal
+# %tile.railcraft.fluid.creosote:* (tile.railcraft.block.fluid.creosote), render=40(CUSTOM), opaque=false,cls=mods.railcraft.common.fluids.BlockRailcraftFluid
+block:id=%tile.railcraft.fluid.creosote,data=*,stdrot=true,transparency=TRANSPARENT,face0-1=0:railcraft/fluids/creosote_still,face2-5=0:railcraft/fluids/creosote_flow
+# %tile.railcraft.fluid.steam:* (tile.railcraft.block.fluid.steam), render=40(CUSTOM), opaque=false,cls=mods.railcraft.common.fluids.BlockRailcraftFluidFinite
+block:id=%tile.railcraft.fluid.steam,data=*,stdrot=true,transparency=TRANSPARENT,face0-5=0:railcraft/fluids/steam_still


### PR DESCRIPTION
I copied over the 1.6.2 Railcraft renderdata, and then I updated the existing definitions to work with 1.7.x. I haven't added anything for newer Railcraft features/blocks
